### PR TITLE
Arquivo contendo o texto da licença apache 2.0 para a lingua portuguesa

### DIFF
--- a/LICENÇA
+++ b/LICENÇA
@@ -1,0 +1,201 @@
+                                  Licença Apache
+                            Versão 2.0, janeiro de 2004
+                         http://www.apache.org/licenses/
+
+    TERMOS E CONDIÇÕES DE UTILIZAÇÃO, REPRODUÇÃO E DISTRIBUIÇÃO
+
+    1. Definições.
+
+       "Licença" significa os termos e condições de uso, reprodução,
+       e distribuição conforme definido pelas Seções 1 a 9 deste documento.
+
+       "Licenciador" significa o proprietário ou entidade autorizada pelo
+       o proprietário dos direitos autorais que está concedendo a licença.
+
+       "Entidade Jurídica" significa a união da entidade em exercício e todos os
+       outras entidades que controlam, são controladas ou estão em
+       controle com essa entidade.  Para os propósitos desta definição,
+       "controle" significa (i) o poder, direto ou indireto, de causar a
+       direcção ou gestão dessa entidade, seja por contrato ou por
+       caso contrário, ou (ii) a titularidade de 50% (cinquenta por cento) ou mais
+       ações em circulação, ou (iii) titularidade de tal entidade.
+
+       "Você" (ou "Seu") significa uma pessoa física ou jurídica
+       exercendo permissões concedidas por esta Licença.
+
+       Formulário "Fonte" significa a forma preferida para fazer modificações,
+       incluindo, mas não se limitando ao código fonte do software, documentação
+       fonte e arquivos de configuração.
+
+       Por "formulário objecto" entende-se qualquer forma resultante de
+       transformação ou tradução de um formulário Fonte, incluindo
+       não se limita ao código de objeto compilado, documentação gerada,
+       e conversões para outros tipos de mídia.
+
+       "Trabalho" significa o trabalho de autoria, seja na Fonte ou
+       Formulário de objetos, disponibilizado sob a Licença, conforme indicado por um
+       aviso de direitos autorais incluído ou anexado ao trabalho
+       (um exemplo é fornecido no Apêndice abaixo).
+
+       "Obras Derivadas" significa qualquer trabalho, seja na Fonte ou no Objeto
+       forma, que é baseado (ou derivado) do Trabalho e para o qual o
+       revisões editoriais, anotações, elaborações ou outras modificações
+       representam, como um todo, um trabalho original de autoria.  Para os propósitos
+       desta Licença, as Obras Derivadas não incluirão trabalhos que permanecem
+       separável de, ou simplesmente vincular (ou vincular por nome) às interfaces de,
+       Obras Obras e Derivadas.
+
+       "Contribuição", qualquer trabalho de autoria, incluindo
+       a versão original do trabalho e quaisquer modificações ou adições
+       a esse trabalho ou trabalhos derivados, isto é, intencionalmente
+       enviado ao Licenciante para inclusão no Trabalho pelo proprietário dos direitos autorais
+       ou por uma pessoa singular ou jurídica autorizada a apresentar em nome de
+       o proprietário dos direitos autorais.  Para os propósitos desta definição, "submetido"
+       significa qualquer forma de comunicação eletrônica, verbal ou escrita enviada
+       ao Licenciador ou seus representantes, incluindo, mas não se limitando a,
+       comunicação em listas de correio electrónico, sistemas de controlo de código fonte,
+       sistemas de rastreamento que são gerenciados por ou em nome do
+       Licenciante com o propósito de discutir e melhorar o Trabalho, mas
+       excluindo a comunicação visivelmente marcada ou não
+       designado por escrito pelo proprietário dos direitos autorais como "Não é uma contribuição".
+
+       "Colaborador" significa o Licenciante e qualquer indivíduo ou Entidade Legal
+       em nome de quem uma Contribuição foi recebida pelo Licenciador e
+       posteriormente incorporada no Trabalho.
+
+    2. Concessão de licença de direitos autorais.  Sujeito aos termos e condições de
+       esta Licença, cada Colaborador concede a Você uma licença perpétua,
+       em todo o mundo, não exclusivo, gratuito, isento de royalties, irrevogável
+       licença de direitos autorais para reproduzir, preparar trabalhos derivados,
+       exibir publicamente, executar publicamente, sublicenciar e distribuir
+       Trabalho e tal derivado funciona no formulário de origem ou objeto.
+
+    3. Concessão de licença de patente.  Sujeito aos termos e condições de
+       esta Licença, cada Colaborador concede a Você uma licença perpétua,
+       em todo o mundo, não exclusivo, gratuito, isento de royalties, irrevogável
+       (exceto como indicado nesta seção) licença de patente para fazer, fizeram,
+       usar, oferecer para vender, vender, importar ou transferir o Trabalho,
+       onde tal licença se aplica somente àquelas reivindicações de patente licenciáveis
+       por tal Colaborador que são necessariamente infringidos por seus
+       Contribuição (s) sozinha (s) ou por combinação de sua (s) contribuição (s)
+       com o trabalho para o qual essa contribuição foi submetida.  Se vocês
+       instituir litígios sobre patentes contra qualquer entidade (incluindo
+       reivindicação cruzada ou reconvenção em uma ação judicial) alegando que a
+       ou uma contribuição incorporada no Trabalho constitui direta
+       ou violação de patente contributiva, então quaisquer licenças de patente
+       concedida a Você sob esta Licença para esse Trabalho terminará
+       a partir da data em que tal litígio for arquivado.
+
+    4. Redistribuição.  Você pode reproduzir e distribuir cópias do
+       Obras ou Obras Derivadas do mesmo, em qualquer meio, com ou sem
+       modificações, e na forma Fonte ou Objeto, desde que você
+       atender as seguintes condições:
+
+       (a) Você deve dar a qualquer outro destinatário da Obra ou
+           Derivativo Trabalha uma cópia desta Licença;  e
+
+       (b) Você deve fazer com que qualquer arquivo modificado contenha avisos proeminentes
+           afirmando que você mudou os arquivos;  e
+
+       (c) Você deve manter, na forma de Fonte de qualquer Obra Derivada
+           que você distribui, todos os direitos autorais, patente, marca comercial e
+           avisos de atribuição da forma Fonte do Trabalho,
+           excluindo aqueles avisos que não dizem respeito a nenhuma parte
+           Obras Derivadas;  e
+
+       (d) Se a Obra incluir um arquivo de texto "AVISO" como parte de sua
+           distribuição, então quaisquer Trabalhos Derivados que você distribuir
+           incluir uma cópia legível dos avisos de atribuição contidos
+           dentro desse arquivo de AVISO, excluindo aqueles avisos que não
+           pertencem a qualquer parte das Obras Derivadas, em pelo menos um
+           dos seguintes locais: dentro de um arquivo de texto de NOTIFICAÇÃO distribuído
+           como parte das Obras Derivadas;  dentro do formulário Fonte ou
+           documentação, se fornecida junto com as Obras Derivadas;  ou,
+           dentro de um display gerado pelo Derivative Works, se e
+           sempre que tais avisos de terceiros normalmente aparecem.  O conteúdo
+           do arquivo de AVISO são apenas para fins informativos e
+           não modifique a licença.  Você pode adicionar sua própria atribuição
+           avisos dentro das Obras Derivadas que Você distribui, ao lado
+           ou como um adendo ao texto de AVISO da Obra, desde que
+           que tais avisos de atribuição adicionais não podem ser interpretados
+           como modificar a licença.
+
+       Você pode adicionar sua própria declaração de direitos autorais às suas modificações e
+       pode fornecer termos e condições de licença adicionais ou diferentes
+       para uso, reprodução ou distribuição de Suas modificações, ou
+       para qualquer obra derivada como um todo, desde o seu uso,
+       reprodução e distribuição da Obra obedece
+       as condições declaradas nesta Licença.
+
+    5. Apresentação de Contribuições.  A menos que você indique explicitamente o contrário,
+       qualquer contribuição submetida intencionalmente para inclusão no Trabalho
+       por Você ao Licenciante deverá estar sob os termos e condições de
+       esta Licença, sem quaisquer termos ou condições adicionais.
+       Não obstante o acima, nada aqui deve substituir ou modificar
+       os termos de qualquer contrato de licença separado que você possa ter executado
+       com o Licenciador em relação a tais Contribuições.
+
+    6. Marcas Registradas.  Esta Licença não concede permissão para usar o comércio
+       nomes, marcas registradas, marcas de serviço ou nomes de produtos do Licenciante,
+       exceto conforme exigido para uso razoável e costumeiro na descrição do
+       origem da Obra e reproduzindo o conteúdo do arquivo de NOTIFICAÇÃO.
+
+    7. Isenção de Garantia.  A menos que exigido pela lei aplicável ou
+       acordado por escrito, o Licenciador fornece o Trabalho (e cada
+       Colaborador fornece suas contribuições) em uma base "COMO ESTÁ",
+       SEM GARANTIAS OU CONDIÇÕES DE QUALQUER TIPO, expressas ou
+       implícito, incluindo, sem limitação, quaisquer garantias ou condições
+       TÍTULO, NÃO VIOLAÇÃO, COMERCIALIZAÇÃO OU ADEQUAÇÃO A UM
+       PROPÓSITO PARTICULAR.  Você é o único responsável por determinar o
+       adequação de usar ou redistribuir o Trabalho e assumir qualquer
+       riscos associados ao Seu exercício de permissões sob esta Licença.
+
+    8. Limitação de responsabilidade.  Em nenhum evento e sob nenhuma teoria legal,
+       se em delito (incluindo negligência), contrato, ou de outra forma,
+       a menos que exigido pela lei aplicável (como deliberada e grosseiramente
+       actos negligentes) ou acordados por escrito, qualquer Colaborador será
+       Responsável por danos, incluindo quaisquer danos diretos, indiretos, especiais,
+       danos incidentais ou consequenciais de qualquer caráter que surjam
+       resultado desta Licença ou fora do uso ou incapacidade de usar o
+       Trabalho (incluindo mas não limitado a danos por perda de boa vontade,
+       paralisação do trabalho, falha do computador ou mau funcionamento, ou qualquer e todos
+       outros prejuízos comerciais ou perdas), mesmo que tal
+       foi avisado da possibilidade de tais danos.
+
+    9. Aceitando Garantia ou Responsabilidade Adicional.  Enquanto redistribuindo
+       Trabalho ou Obra Derivada, você pode optar por oferecer,
+       cobrar uma taxa pela aceitação do suporte, garantia, indenização,
+       ou outras obrigações de responsabilidade e / ou direitos consistentes com este
+       Licença.  No entanto, ao aceitar tais obrigações, você pode agir apenas
+       em seu próprio nome e sob sua exclusiva responsabilidade, não em nome
+       de qualquer outro Colaborador, e somente se você concordar em indenizar,
+       defender e responsabilizar cada Colaborador por qualquer responsabilidade
+       incorridos por, ou reclamações feitas contra tal Colaborador pela razão
+       de aceitar qualquer garantia ou responsabilidade adicional.
+
+    FIM DOS TERMOS E CONDIÇÕES
+
+    APÊNDICE: Como aplicar a licença Apache ao seu trabalho.
+
+       Para aplicar a Licença Apache ao seu trabalho, anexe o seguinte
+       aviso de boilerplate, com os campos entre colchetes "[]"
+       substituído por sua própria informação de identificação.  (Não inclua
+       os colchetes!) O texto deve ser incluído no arquivo apropriado.
+       sintaxe de comentário para o formato de arquivo.  Também recomendamos que um
+       arquivo ou nome da classe e descrição do propósito ser incluído no
+       mesma "página impressa" como aviso de direitos autorais para facilitar
+       identificação em arquivos de terceiros.
+
+    Copyright [aaaa] [nome do proprietário dos direitos autorais]
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.


### PR DESCRIPTION
Licença Apache 2.0 traduzida para o Português do Brasil.
Fonte: [Licença Apache 2.0 - Google Translate](https://translate.google.com.br/translate?hl=pt-BR&sl=en&tl=pt&u=https%3A%2F%2Fchoosealicense.com%2Flicenses%2Fapache-2.0%2F)